### PR TITLE
Add selective fuzz darkening

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -2497,6 +2497,13 @@ default_t defaults[] = {
     "0 original, 1 blocky (hires)"
   },
 
+  {
+    "fuzzdark_mode",
+    (config_t *) &fuzzdark_mode, NULL,
+    {0}, {0,1}, number, ss_enem, wad_no,
+    "0 original, 1 selective"
+  },
+
   {NULL}         // last entry
 };
 

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -453,6 +453,9 @@ void R_SetFuzzPosDraw(void)
 //  i.e. spectres and invisible players.
 //
 
+static const int fuzzdark = 6 * 256;
+int fuzzdark_mode;
+
 static void R_DrawFuzzColumn_orig(void)
 { 
   int      count; 
@@ -507,7 +510,8 @@ static void R_DrawFuzzColumn_orig(void)
       // fraggle 1/8/2000: fix with the bugfix from lees
       // why_i_left_doom.html
 
-      *dest = fullcolormap[6*256+dest[fuzzoffset[fuzzpos++] ? linesize : -linesize]];
+      const int dark = (!fuzzdark_mode || (fuzzoffset[fuzzpos] == -1 && (count != dc_yh - dc_yl + 1))) ? fuzzdark : 0;
+      *dest = fullcolormap[dark+dest[fuzzoffset[fuzzpos++] ? linesize : -linesize]];
       dest += linesize;             // killough 11/98
 
       // Clamp table lookup index.
@@ -519,7 +523,8 @@ static void R_DrawFuzzColumn_orig(void)
   // draw one extra line using only pixels of that line and the one above
   if (cutoff)
   {
-    *dest = fullcolormap[6*256+dest[linesize*fuzzoffset[fuzzpos]]];
+    const int dark = (!fuzzdark_mode || fuzzoffset[fuzzpos] == 0) ? fuzzdark : 0;
+    *dest = fullcolormap[dark+dest[linesize*fuzzoffset[fuzzpos]]];
   }
 }
 
@@ -572,7 +577,8 @@ static void R_DrawFuzzColumn_block(void)
     {
       // [FG] draw only even pixels as 2x2 squares
       //      using the same fuzzoffset value
-      const byte fuzz = fullcolormap[6*256+dest[fuzzoffset[fuzzpos] ? 2*linesize : -2*linesize]];
+      const int dark = (!fuzzdark_mode || (fuzzoffset[fuzzpos] == -1 && (count != dc_yh - dc_yl + 2))) ? fuzzdark : 0;
+      const byte fuzz = fullcolormap[dark+dest[fuzzoffset[fuzzpos] ? 2*linesize : -2*linesize]];
 
       dest[0] = fuzz;
       dest[1] = fuzz;
@@ -589,7 +595,8 @@ static void R_DrawFuzzColumn_block(void)
 
   if (cutoff)
     {
-      const byte fuzz = fullcolormap[6*256+dest[2*linesize*fuzzoffset[fuzzpos]]];
+      const int dark = (!fuzzdark_mode || fuzzoffset[fuzzpos] == 0) ? fuzzdark : 0;
+      const byte fuzz = fullcolormap[dark+dest[2*linesize*fuzzoffset[fuzzpos]]];
 
       dest[0] = fuzz;
       dest[1] = fuzz;

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -60,6 +60,8 @@ void R_SetFuzzPosDraw(void);
 extern int fuzzcolumn_mode;
 void R_SetFuzzColumnMode(void);
 
+extern int fuzzdark_mode;
+
 void R_DrawSkyColumn(void);
 
 // Draw with color translation tables, for player sprite rendering,


### PR DESCRIPTION
Ceski's implementation of [Linguica's "fixed" sprite fuzz](https://www.doomworld.com/forum/topic/57270/?page=100&tab=comments#comment-1335769).

Required settings:
```
hires 1
fuzzcolumn_mode 1
fuzzdark_mode 1
```